### PR TITLE
Allow setting certain parser states & add `StartTag::next_state`

### DIFF
--- a/examples/switch-state.rs
+++ b/examples/switch-state.rs
@@ -1,0 +1,19 @@
+//! Let's you easily try out the tokenizer with e.g.
+//! printf '<style><b>Hello world!</b></style>' | cargo run --example=switch-state
+use html5gum::{BufReadReader, Token, Tokenizer};
+use std::io::stdin;
+
+fn main() {
+    let stdin = stdin();
+    let mut tokenizer = Tokenizer::new(BufReadReader::new(stdin.lock()));
+
+    while let Some(token) = tokenizer.next() {
+        let token = token.unwrap();
+        println!("{:?}", token);
+
+        if let Token::StartTag(start_tag) = token {
+            // take care of switching parser state for e.g. <script> & <style>
+            tokenizer.set_state(start_tag.next_state(false));
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,4 +19,4 @@ pub use emitter::{DefaultEmitter, Doctype, Emitter, EndTag, StartTag, Token};
 pub use error::Error;
 pub use never::Never;
 pub use reader::{BufReadReader, Readable, Reader, StringReader};
-pub use tokenizer::{InfallibleTokenizer, Tokenizer};
+pub use tokenizer::{InfallibleTokenizer, State, Tokenizer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod tokenizer;
 mod utils;
 
 #[cfg(feature = "integration-tests")]
-pub use utils::State;
+pub use utils::State as InternalState;
 
 pub use emitter::{DefaultEmitter, Doctype, Emitter, EndTag, StartTag, Token};
 pub use error::Error;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -326,7 +326,7 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             }
             c => {
                 slf.emitter.emit_string("<");
-                slf.state = State::Data;
+                slf.state = State::ScriptData;
                 slf.unread_char(c);
                 Ok(ControlToken::Continue)
             }

--- a/tests/test_html5lib.rs
+++ b/tests/test_html5lib.rs
@@ -1,4 +1,6 @@
-use html5gum::{Doctype, EndTag, Error, Reader, StartTag, State, Token, Tokenizer};
+use html5gum::{
+    Doctype, EndTag, Error, InternalState as State, Reader, StartTag, Token, Tokenizer,
+};
 use pretty_assertions::assert_eq;
 use serde::{de::Error as _, Deserialize};
 use std::{collections::BTreeMap, fs::File, io::BufReader, path::Path};
@@ -258,7 +260,7 @@ fn run_test_inner<R: Reader>(
         fname, test_i, state, tokenizer_info,
     );
     println!("description: {}", test.description);
-    tokenizer.set_state(state);
+    tokenizer.set_internal_state(state);
     tokenizer.set_last_start_tag(test.last_start_tag.as_ref().map(String::as_str));
 
     let mut actual_tokens = Vec::new();


### PR DESCRIPTION
The second commit allows users to set the same states the html5ever tokenizer allows to be set via its [`TokenSinkResult`](https://docs.rs/html5ever/0.25.1/html5ever/tokenizer/enum.TokenSinkResult.html) type. Providing a public API for this is necessary for everybody who wants to handle e.g. `script` and `style` tags.

Closes #11.