### PR TITLE
fix wrong script data-related transition

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -326,7 +326,7 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             }
             c => {
                 slf.emitter.emit_string("<");
-                slf.state = State::Data;
+                slf.state = State::ScriptData;
                 slf.unread_char(c);
                 Ok(ControlToken::Continue)
             }


### PR DESCRIPTION
In #11 it was discovered that script data state is parsed wrongly.

We should ideally contribute a test to html5lib-tests.