### PR TITLE
Refactor to use memchr heavily

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,13 @@ serde_json = "1.0.71"
 test-generator = "0.3.0"
 
 [features]
+# By default this crate depends on the memchr library for best performance.
+# Disabling this feature will leave you with 100% safe Rust and no dependencies.
+# This may come in handy if you encounter packaging/build problems.
+default = ["memchr"]
+
 # Feature used by integration tests in tests/ to get access to library internals.
 integration-tests = []
+
+[dependencies]
+memchr = { version = "2.4.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ This allows you to:
   you, you can implement the respective trait methods as noop and therefore
   avoid any overhead creating plaintext tokens.
 
+## Other features
+
+* No unsafe Rust
+* Only dependency is `memchr`, and can be disabled via crate features (see `Cargo.toml`)
+
 ## Alternative HTML parsers
 
 `html5gum` was created out of a need to parse HTML tag soup efficiently. Previous options were to:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 // This is an HTML parser. HTML can be untrusted input from the internet.
 #![forbid(unsafe_code)]
 #![doc = include_str!("../README.md")]
@@ -7,7 +7,9 @@ mod emitter;
 mod entities;
 mod error;
 mod machine;
+mod machine_helper;
 mod never;
+mod read_helper;
 mod reader;
 mod tokenizer;
 mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,10 @@ mod tokenizer;
 mod utils;
 
 #[cfg(feature = "integration-tests")]
-pub use utils::State;
+mod slow_reader;
+
+#[cfg(feature = "integration-tests")]
+pub use {slow_reader::SlowReader, utils::State};
 
 pub use emitter::{DefaultEmitter, Doctype, Emitter, EndTag, StartTag, Token};
 pub use error::Error;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1352,9 +1352,7 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
         State::BeforeDoctypeName => Ok({
             let emitter = &mut slf.emitter;
             match slf.reader.read_char(emitter)? {
-                Some(whitespace_pat!()) => {
-                    ControlToken::Continue
-                }
+                Some(whitespace_pat!()) => ControlToken::Continue,
                 Some('\0') => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.init_doctype();

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -33,25 +33,25 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("&")) => {
+                Some("&") => {
                     machine_helper.return_state = Some(machine_helper.state);
                     machine_helper.state = State::CharacterReference;
                     ControlToken::Continue
                 }
-                (Some("<")) => {
+                Some("<") => {
                     machine_helper.state = State::TagOpen;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.emit_string("\0");
                     ControlToken::Continue
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.emit_string(xs);
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     ControlToken::Eof
                 }
             }
@@ -61,25 +61,25 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("&")) => {
+                Some("&") => {
                     machine_helper.return_state = Some(State::RcData);
                     machine_helper.state = State::CharacterReference;
                     ControlToken::Continue
                 }
-                (Some("<")) => {
+                Some("<") => {
                     machine_helper.state = State::RcDataLessThanSign;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.emit_string("\u{fffd}");
                     ControlToken::Continue
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.emit_string(xs);
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     ControlToken::Eof
                 }
             }
@@ -88,20 +88,20 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("<")) => {
+                Some("<") => {
                     machine_helper.state = State::RawTextLessThanSign;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.emit_string("\u{fffd}");
                     ControlToken::Continue
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.emit_string(xs);
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     ControlToken::Eof
                 }
             }
@@ -110,20 +110,20 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("<")) => {
+                Some("<") => {
                     machine_helper.state = State::ScriptDataLessThanSign;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.emit_string("\u{fffd}");
                     ControlToken::Continue
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.emit_string(xs);
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     ControlToken::Eof
                 }
             }
@@ -132,16 +132,16 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.emit_string("\u{fffd}");
                     ControlToken::Continue
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.emit_string(xs);
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     ControlToken::Eof
                 }
             }
@@ -216,32 +216,32 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("\t" | "\u{0A}" | "\u{0C}" | " ")) => {
+                Some("\t" | "\u{0A}" | "\u{0C}" | " ") => {
                     machine_helper.state = State::BeforeAttributeName;
                     ControlToken::Continue
                 }
-                (Some("/")) => {
+                Some("/") => {
                     machine_helper.state = State::SelfClosingStartTag;
                     ControlToken::Continue
                 }
-                (Some(">")) => {
+                Some(">") => {
                     machine_helper.state = State::Data;
                     emitter.emit_current_tag();
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.push_tag_name("\u{fffd}");
                     ControlToken::Continue
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     // TODO: slow
                     for x in xs.chars() {
                         emitter.push_tag_name(ctostr!(x.to_ascii_lowercase()));
                     }
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInTag);
                     ControlToken::Eof
                 }
@@ -477,25 +477,25 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("-")) => {
+                Some("-") => {
                     machine_helper.state = State::ScriptDataEscapedDash;
                     emitter.emit_string("-");
                     ControlToken::Continue
                 }
-                (Some("<")) => {
+                Some("<") => {
                     machine_helper.state = State::ScriptDataEscapedLessThanSign;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.emit_string("\u{fffd}");
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInScriptHtmlCommentLikeText);
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.emit_string(xs);
                     ControlToken::Continue
                 }
@@ -505,26 +505,26 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("-")) => {
+                Some("-") => {
                     machine_helper.state = State::ScriptDataEscapedDashDash;
                     emitter.emit_string("-");
                     ControlToken::Continue
                 }
-                (Some("<")) => {
+                Some("<") => {
                     machine_helper.state = State::ScriptDataEscapedLessThanSign;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     machine_helper.state = State::ScriptDataEscaped;
                     emitter.emit_string("\u{fffd}");
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInScriptHtmlCommentLikeText);
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     machine_helper.state = State::ScriptDataEscaped;
                     emitter.emit_string(xs);
                     ControlToken::Continue
@@ -535,30 +535,30 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("-")) => {
+                Some("-") => {
                     emitter.emit_string("-");
                     ControlToken::Continue
                 }
-                (Some("<")) => {
+                Some("<") => {
                     machine_helper.state = State::ScriptDataEscapedLessThanSign;
                     ControlToken::Continue
                 }
-                (Some(">")) => {
+                Some(">") => {
                     machine_helper.state = State::ScriptData;
                     emitter.emit_string(">");
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     machine_helper.state = State::ScriptDataEscaped;
                     emitter.emit_string("\u{fffd}");
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInScriptHtmlCommentLikeText);
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     machine_helper.state = State::ScriptDataEscaped;
                     emitter.emit_string(xs);
                     ControlToken::Continue
@@ -663,26 +663,26 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("-")) => {
+                Some("-") => {
                     machine_helper.state = State::ScriptDataDoubleEscapedDash;
                     emitter.emit_string("-");
                     ControlToken::Continue
                 }
-                (Some("<")) => {
+                Some("<") => {
                     machine_helper.state = State::ScriptDataDoubleEscapedLessThanSign;
                     emitter.emit_string("<");
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.emit_string("\u{fffd}");
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInScriptHtmlCommentLikeText);
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.emit_string(xs);
                     ControlToken::Continue
                 }
@@ -692,27 +692,27 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("-")) => {
+                Some("-") => {
                     machine_helper.state = State::ScriptDataDoubleEscapedDashDash;
                     emitter.emit_string("-");
                     ControlToken::Continue
                 }
-                (Some("<")) => {
+                Some("<") => {
                     machine_helper.state = State::ScriptDataDoubleEscapedLessThanSign;
                     emitter.emit_string("<");
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     machine_helper.state = State::ScriptDataDoubleEscaped;
                     emitter.emit_string("\u{fffd}");
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInScriptHtmlCommentLikeText);
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     machine_helper.state = State::ScriptDataDoubleEscaped;
                     emitter.emit_string(xs);
                     ControlToken::Continue
@@ -723,31 +723,31 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("-")) => {
+                Some("-") => {
                     emitter.emit_string("-");
                     ControlToken::Continue
                 }
-                (Some("<")) => {
+                Some("<") => {
                     emitter.emit_string("<");
                     machine_helper.state = State::ScriptDataDoubleEscapedLessThanSign;
                     ControlToken::Continue
                 }
-                (Some(">")) => {
+                Some(">") => {
                     emitter.emit_string(">");
                     machine_helper.state = State::ScriptData;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     machine_helper.state = State::ScriptDataDoubleEscaped;
                     emitter.emit_string("\u{fffd}");
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInScriptHtmlCommentLikeText);
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     machine_helper.state = State::ScriptDataDoubleEscaped;
                     emitter.emit_string(xs);
                     ControlToken::Continue
@@ -905,25 +905,25 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("\"")) => {
+                Some("\"") => {
                     machine_helper.state = State::AfterAttributeValueQuoted;
                     ControlToken::Continue
                 }
-                (Some("&")) => {
+                Some("&") => {
                     machine_helper.return_state = Some(State::AttributeValueDoubleQuoted);
                     machine_helper.state = State::CharacterReference;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.push_attribute_value("\u{fffd}");
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInTag);
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.push_attribute_value(xs);
                     ControlToken::Continue
                 }
@@ -933,25 +933,25 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("'")) => {
+                Some("'") => {
                     machine_helper.state = State::AfterAttributeValueQuoted;
                     ControlToken::Continue
                 }
-                (Some("&")) => {
+                Some("&") => {
                     machine_helper.return_state = Some(State::AttributeValueSingleQuoted);
                     machine_helper.state = State::CharacterReference;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.push_attribute_value("\u{fffd}");
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInTag);
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.push_attribute_value(xs);
                     ControlToken::Continue
                 }
@@ -961,35 +961,35 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("\t" | "\u{0A}" | "\u{0C}" | " ")) => {
+                Some("\t" | "\u{0A}" | "\u{0C}" | " ") => {
                     machine_helper.state = State::BeforeAttributeName;
                     ControlToken::Continue
                 }
-                (Some("&")) => {
+                Some("&") => {
                     machine_helper.return_state = Some(State::AttributeValueUnquoted);
                     machine_helper.state = State::CharacterReference;
                     ControlToken::Continue
                 }
-                (Some(">")) => {
+                Some(">") => {
                     machine_helper.state = State::Data;
                     emitter.emit_current_tag();
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.push_attribute_value("\u{fffd}");
                     ControlToken::Continue
                 }
-                (Some(xs @ ("\"" | "'" | "<" | "=" | "\u{60}"))) => {
+                Some(xs @ ("\"" | "'" | "<" | "=" | "\u{60}")) => {
                     emitter.emit_error(Error::UnexpectedCharacterInUnquotedAttributeValue);
                     emitter.push_attribute_value(xs);
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInTag);
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.push_attribute_value(xs);
                     ControlToken::Continue
                 }
@@ -1048,21 +1048,21 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some(">")) => {
+                Some(">") => {
                     machine_helper.state = State::Data;
                     emitter.emit_current_comment();
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_current_comment();
                     ControlToken::Eof
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.push_comment("\u{fffd}");
                     ControlToken::Continue
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.push_comment(xs);
                     ControlToken::Continue
                 }
@@ -1153,26 +1153,26 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("<")) => {
+                Some("<") => {
                     emitter.push_comment("<");
                     machine_helper.state = State::CommentLessThanSign;
                     ControlToken::Continue
                 }
-                (Some("-")) => {
+                Some("-") => {
                     machine_helper.state = State::CommentEndDash;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.push_comment("\u{fffd}");
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInComment);
                     emitter.emit_current_comment();
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.push_comment(xs);
                     ControlToken::Continue
                 }
@@ -1387,27 +1387,27 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("\t" | "\u{0A}" | "\u{0C}" | " ")) => {
+                Some("\t" | "\u{0A}" | "\u{0C}" | " ") => {
                     machine_helper.state = State::AfterDoctypeName;
                     ControlToken::Continue
                 }
-                (Some(">")) => {
+                Some(">") => {
                     machine_helper.state = State::Data;
                     emitter.emit_current_doctype();
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.push_doctype_name("\u{fffd}");
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInDoctype);
                     emitter.set_force_quirks();
                     emitter.emit_current_doctype();
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     // TODO: slow
                     for x in xs.chars() {
                         emitter.push_doctype_name(ctostr!(x.to_ascii_lowercase()));
@@ -1529,29 +1529,29 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("\"")) => {
+                Some("\"") => {
                     machine_helper.state = State::AfterDoctypePublicIdentifier;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.push_doctype_public_identifier("\u{fffd}");
                     ControlToken::Continue
                 }
-                (Some(">")) => {
+                Some(">") => {
                     emitter.emit_error(Error::AbruptDoctypePublicIdentifier);
                     emitter.set_force_quirks();
                     machine_helper.state = State::Data;
                     emitter.emit_current_doctype();
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInDoctype);
                     emitter.set_force_quirks();
                     emitter.emit_current_doctype();
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.push_doctype_public_identifier(xs);
                     ControlToken::Continue
                 }
@@ -1561,29 +1561,29 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("'")) => {
+                Some("'") => {
                     machine_helper.state = State::AfterDoctypePublicIdentifier;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.push_doctype_public_identifier("\u{fffd}");
                     ControlToken::Continue
                 }
-                (Some(">")) => {
+                Some(">") => {
                     emitter.emit_error(Error::AbruptDoctypePublicIdentifier);
                     emitter.set_force_quirks();
                     machine_helper.state = State::Data;
                     emitter.emit_current_doctype();
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInDoctype);
                     emitter.set_force_quirks();
                     emitter.emit_current_doctype();
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.push_doctype_public_identifier(xs);
                     ControlToken::Continue
                 }
@@ -1747,29 +1747,29 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("\"")) => {
+                Some("\"") => {
                     machine_helper.state = State::AfterDoctypeSystemIdentifier;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.push_doctype_system_identifier("\u{fffd}");
                     ControlToken::Continue
                 }
-                (Some(">")) => {
+                Some(">") => {
                     emitter.emit_error(Error::AbruptDoctypeSystemIdentifier);
                     emitter.set_force_quirks();
                     machine_helper.state = State::Data;
                     emitter.emit_current_doctype();
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInDoctype);
                     emitter.set_force_quirks();
                     emitter.emit_current_doctype();
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.push_doctype_system_identifier(xs);
                     ControlToken::Continue
                 }
@@ -1779,29 +1779,29 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("\'")) => {
+                Some("\'") => {
                     machine_helper.state = State::AfterDoctypeSystemIdentifier;
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     emitter.push_doctype_system_identifier("\u{fffd}");
                     ControlToken::Continue
                 }
-                (Some(">")) => {
+                Some(">") => {
                     emitter.emit_error(Error::AbruptDoctypeSystemIdentifier);
                     emitter.set_force_quirks();
                     machine_helper.state = State::Data;
                     emitter.emit_current_doctype();
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInDoctype);
                     emitter.set_force_quirks();
                     emitter.emit_current_doctype();
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.push_doctype_system_identifier(xs);
                     ControlToken::Continue
                 }
@@ -1834,20 +1834,20 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some(">")) => {
+                Some(">") => {
                     machine_helper.state = State::Data;
                     emitter.emit_current_doctype();
                     ControlToken::Continue
                 }
-                (Some("\0")) => {
+                Some("\0") => {
                     emitter.emit_error(Error::UnexpectedNullCharacter);
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_current_doctype();
                     ControlToken::Eof
                 }
-                (Some(_xs)) => {
+                Some(_xs) => {
                     ControlToken::Continue
                 }
             }
@@ -1856,15 +1856,15 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
             slf,
             emitter,
             match READ_CHAR {
-                (Some("]")) => {
+                Some("]") => {
                     machine_helper.state = State::CdataSectionBracket;
                     ControlToken::Continue
                 }
-                (None) => {
+                None => {
                     emitter.emit_error(Error::EofInCdata);
                     ControlToken::Eof
                 }
-                (Some(xs)) => {
+                Some(xs) => {
                     emitter.emit_string(xs);
                     ControlToken::Continue
                 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1847,9 +1847,7 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
                     emitter.emit_current_doctype();
                     ControlToken::Eof
                 }
-                Some(_xs) => {
-                    ControlToken::Continue
-                }
+                Some(_xs) => ControlToken::Continue,
             }
         ),
         State::CdataSection => fast_read_char!(

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1845,7 +1845,8 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
 
                 if !machine_helper.is_consumed_as_part_of_an_attribute()
                     || char_ref_name_last_character == Some(';')
-                    || !matches!(next_character, Some(x) if x == '=' || x.is_ascii_alphanumeric()) {
+                    || !matches!(next_character, Some(x) if x == '=' || x.is_ascii_alphanumeric())
+                {
                     if char_ref_name_last_character != Some(';') {
                         emitter.emit_error(Error::MissingSemicolonAfterCharacterReference);
                     }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -2,7 +2,7 @@ use crate::entities::try_read_character_reference;
 use crate::read_helper::fast_read_char;
 use crate::utils::{
     ascii_digit_pat, control_pat, ctostr, noncharacter_pat, surrogate_pat, whitespace_pat,
-    ControlToken, State,
+    with_lowercase_str, ControlToken, State,
 };
 use crate::{Emitter, Error, Reader, Tokenizer};
 
@@ -233,10 +233,10 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
                     ControlToken::Continue
                 }
                 Some(xs) => {
-                    // TODO: slow
-                    for x in xs.chars() {
-                        emitter.push_tag_name(ctostr!(x.to_ascii_lowercase()));
-                    }
+                    with_lowercase_str(xs, |x| {
+                        emitter.push_tag_name(x);
+                    });
+
                     ControlToken::Continue
                 }
                 None => {
@@ -1320,10 +1320,9 @@ pub fn consume<R: Reader, E: Emitter>(slf: &mut Tokenizer<R, E>) -> Result<Contr
                     ControlToken::Eof
                 }
                 Some(xs) => {
-                    // TODO: slow
-                    for x in xs.chars() {
-                        emitter.push_doctype_name(ctostr!(x.to_ascii_lowercase()));
-                    }
+                    with_lowercase_str(xs, |x| {
+                        emitter.push_doctype_name(x);
+                    });
                     ControlToken::Continue
                 }
             }

--- a/src/machine_helper.rs
+++ b/src/machine_helper.rs
@@ -5,7 +5,18 @@ pub(crate) struct MachineHelper {
     pub temporary_buffer: String,
     pub character_reference_code: u32,
     pub state: State,
-    pub return_state: Option<State>,
+    return_state: Option<State>,
+}
+
+impl Default for MachineHelper {
+    fn default() -> Self {
+        MachineHelper {
+            temporary_buffer: String::new(),
+            character_reference_code: 0,
+            state: State::Data,
+            return_state: None,
+        }
+    }
 }
 
 impl MachineHelper {
@@ -33,5 +44,18 @@ impl MachineHelper {
     pub(crate) fn flush_buffer_characters<E: Emitter>(&mut self, emitter: &mut E) {
         emitter.emit_string(&self.temporary_buffer);
         self.temporary_buffer.clear();
+    }
+
+    pub(crate) fn enter_state(&mut self, state: State) {
+        self.return_state = Some(self.state);
+        self.state = state;
+    }
+
+    pub(crate) fn pop_return_state(&mut self) -> State {
+        self.return_state.take().unwrap()
+    }
+
+    pub(crate) fn exit_state(&mut self) {
+        self.state = self.pop_return_state();
     }
 }

--- a/src/read_helper.rs
+++ b/src/read_helper.rs
@@ -1,0 +1,269 @@
+use crate::Emitter;
+use crate::Error;
+use crate::Reader;
+
+use crate::utils::{control_pat, ctostr, noncharacter_pat, surrogate_pat};
+
+pub(crate) struct ReadHelper<R: Reader> {
+    reader: R,
+    to_reconsume: Stack2<Option<char>>,
+}
+
+impl<R: Reader> ReadHelper<R> {
+    pub(crate) fn new(reader: R) -> Self {
+        ReadHelper {
+            reader,
+            to_reconsume: Default::default(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn read_char<E: Emitter>(
+        &mut self,
+        emitter: &mut E,
+    ) -> Result<Option<char>, R::Error> {
+        let (c_res, reconsumed) = match self.to_reconsume.pop() {
+            Some(c) => (Ok(c), true),
+            None => (self.reader.read_char(), false),
+        };
+
+        let mut c = match c_res {
+            Ok(Some(c)) => c,
+            res => return res,
+        };
+
+        if c == '\r' {
+            c = '\n';
+            let c2 = self.reader.read_char()?;
+            if c2 != Some('\n') {
+                self.unread_char(c2);
+            }
+        }
+
+        if !reconsumed {
+            Self::validate_char(emitter, c);
+        }
+
+        Ok(Some(c))
+    }
+
+    #[inline]
+    pub(crate) fn try_read_string(
+        &mut self,
+        mut s: &str,
+        case_sensitive: bool,
+    ) -> Result<bool, R::Error> {
+        debug_assert!(!s.is_empty());
+
+        let to_reconsume_bak = self.to_reconsume;
+        let mut chars = s.chars();
+        while let Some(c) = self.to_reconsume.pop() {
+            if let (Some(x), Some(x2)) = (c, chars.next()) {
+                if x == x2 || (!case_sensitive && x.to_ascii_lowercase() == x2.to_ascii_lowercase())
+                {
+                    s = &s[x.len_utf8()..];
+                    continue;
+                }
+            }
+
+            self.to_reconsume = to_reconsume_bak;
+            return Ok(false);
+        }
+
+        self.reader.try_read_string(s, case_sensitive)
+    }
+
+    #[inline]
+    pub(crate) fn read_until<V, F: FnMut(Option<&str>, &mut E) -> V, E: Emitter>(
+        &mut self,
+        needle: &[char],
+        emitter: &mut E,
+        mut read_cb: F,
+    ) -> Result<V, R::Error> {
+        match self.to_reconsume.pop() {
+            Some(Some(x)) => Ok(read_cb(Some(ctostr!(x)), emitter)),
+            Some(None) => Ok(read_cb(None, emitter)),
+            None => {
+                let mut last_character_was_cr = false;
+
+                loop {
+                    let rv = self.reader.read_until(needle, |xs| {
+                        match xs {
+                            Some(xs) if xs.find(&['\r', '\n'][..]).is_some() => {
+                                let mut last_rv = None;
+
+                                // TODO: slow
+                                for x in xs.chars() {
+                                    if x == '\r' {
+                                        last_rv = Some(read_cb(Some("\n"), emitter));
+                                        last_character_was_cr = true;
+                                    } else if x == '\n' {
+                                        if !last_character_was_cr {
+                                            last_rv = Some(read_cb(Some("\n"), emitter));
+                                        }
+                                        last_character_was_cr = false;
+                                    } else {
+                                        Self::validate_char(emitter, x);
+                                        last_rv = Some(read_cb(Some(ctostr!(x)), emitter));
+                                        last_character_was_cr = false;
+                                    }
+                                }
+                                last_rv
+                            }
+                            xs => {
+                                if let Some(xs) = xs {
+                                    for x in xs.chars() {
+                                        Self::validate_char(emitter, x);
+                                    }
+                                }
+                                last_character_was_cr = false;
+                                Some(read_cb(xs, emitter))
+                            }
+                        }
+                    })?;
+
+                    if !last_character_was_cr {
+                        if let Some(rv) = rv {
+                            break Ok(rv);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn unread_char(&mut self, c: Option<char>) {
+        self.to_reconsume.push(c);
+    }
+
+    #[inline]
+    fn validate_char<E: Emitter>(emitter: &mut E, c: char) {
+        match c as u32 {
+            surrogate_pat!() => {
+                emitter.emit_error(Error::SurrogateInInputStream);
+            }
+            noncharacter_pat!() => {
+                emitter.emit_error(Error::NoncharacterInInputStream);
+            }
+            // control without whitespace or nul
+            x @ control_pat!()
+                if !matches!(x, 0x0000 | 0x0009 | 0x000a | 0x000c | 0x000d | 0x0020) =>
+            {
+                emitter.emit_error(Error::ControlCharacterInInputStream);
+            }
+            _ => (),
+        }
+    }
+}
+
+// this is a stack that can hold 0 to 2 Ts
+#[derive(Debug, Default, Clone, Copy)]
+struct Stack2<T: Copy>(Option<(T, Option<T>)>);
+
+impl<T: Copy> Stack2<T> {
+    #[inline]
+    fn push(&mut self, c: T) {
+        self.0 = match self.0 {
+            None => Some((c, None)),
+            Some((c1, None)) => Some((c1, Some(c))),
+            Some((_c1, Some(_c2))) => panic!("stack full!"),
+        }
+    }
+
+    #[inline]
+    fn pop(&mut self) -> Option<T> {
+        let (new_self, rv) = match self.0 {
+            Some((c1, Some(c2))) => (Some((c1, None)), Some(c2)),
+            Some((c1, None)) => (None, Some(c1)),
+            None => (None, None),
+        };
+        self.0 = new_self;
+        rv
+    }
+}
+
+macro_rules! produce_needle {
+    (($($acc:tt)*); Some($var:ident @ ($($pattern:tt)*)) $($rest:tt)*) => {
+        $crate::read_helper::produce_needle!(
+            ($($acc)*);
+            Some($($pattern)*)
+            $($rest)*
+        )
+    };
+
+    (($($acc:tt)*); Some($($x:literal)|*) $($rest:tt)*) => {
+        $crate::read_helper::produce_needle!((
+            $($acc)*
+            $(
+            {
+                debug_assert_eq!($x.len(), 1);
+                $x.chars().next().unwrap()
+            },
+            )*
+        ); $($rest)*)
+    };
+    (($($acc:tt)*); Some($x:ident) $($rest:tt)*) => {
+        $crate::read_helper::produce_needle!(($($acc)*); $($rest)*)
+    };
+    (($($acc:tt)*); c $($rest:tt)*) => {
+        $crate::read_helper::produce_needle!(($($acc)*); $($rest)*)
+    };
+    (($($acc:tt)*); None $($rest:tt)*) => {
+        $crate::read_helper::produce_needle!(($($acc)*); $($rest)*)
+    };
+    (($($acc:tt)*); , $($rest:tt)*) => {
+        $crate::read_helper::produce_needle!(($($acc)*); $($rest)*)
+    };
+    (($($acc:tt)*); ) => {
+        [ $($acc)* ]
+    };
+}
+
+/// A version of `match read_helper.read_char()` that "knows" about matched characters, so it can
+/// produce a more efficient `read_until` call instead.
+///
+/// An extremely limited subset of match patterns is supported.
+///
+/// ```rust
+/// # This documentation example isnt actually running. See
+/// # https://users.rust-lang.org/t/rustdoc-doctests-and-private-documentation/20955/6
+///
+/// use crate::{Reader, Tokenizer};
+///
+/// fn before<R: Reader>(slf: &mut Tokenizer<R>) {
+///     match slf.reader.read_char() {
+///         Some("<") => todo!(),
+///         Some(x) => todo!(),
+///         None => todo!()
+///     }
+/// }
+///
+/// fn after<R: Reader>(slf: &mut Tokenizer<R>) {
+///     fast_read_char!(slf, emitter, match READ_CHAR {
+///         (Some("<")) => {
+///             todo!()
+///         }
+///         (Some(x)) => {
+///             todo!()
+///         }
+///         (None) => {
+///             todo!()
+///         }
+///     })
+/// }
+/// ```
+macro_rules! fast_read_char {
+    ($slf:expr, $emitter:ident, match READ_CHAR { $(($($pattern:tt)*) => $code:block)* }) => {
+        $slf.reader.read_until(
+            &$crate::read_helper::produce_needle!((); $($($pattern)*,)*),
+            &mut $slf.emitter,
+            |xs, $emitter| match xs {
+                $( $($pattern)* => $code ),*
+            }
+        )
+    };
+}
+
+pub(crate) use fast_read_char;
+pub(crate) use produce_needle;

--- a/src/read_helper.rs
+++ b/src/read_helper.rs
@@ -215,6 +215,18 @@ macro_rules! produce_needle {
     (($($acc:tt)*); , $($rest:tt)*) => {
         $crate::read_helper::produce_needle!(($($acc)*); $($rest)*)
     };
+    (($($acc:tt)*); => $($rest:tt)*) => {
+        $crate::read_helper::produce_needle!(($($acc)*); $($rest)*)
+    };
+    (($($acc:tt)*); { $($garbage:tt)* } $($rest:tt)*) => {
+        $crate::read_helper::produce_needle!(($($acc)*); $($rest)*)
+    };
+    (($($acc:tt)*); ( $($pattern:tt)* ) $($rest:tt)*) => {
+        $crate::read_helper::produce_needle!(
+            ($($acc)*);
+            $($pattern)* $($rest)*
+        )
+    };
     (($($acc:tt)*); ) => {
         [ $($acc)* ]
     };
@@ -254,12 +266,12 @@ macro_rules! produce_needle {
 /// }
 /// ```
 macro_rules! fast_read_char {
-    ($slf:expr, $emitter:ident, match READ_CHAR { $(($($pattern:tt)*) => $code:block)* }) => {
+    ($slf:expr, $emitter:ident, match READ_CHAR { $($arms:tt)* }) => {
         $slf.reader.read_until(
-            &$crate::read_helper::produce_needle!((); $($($pattern)*,)*),
+            &$crate::read_helper::produce_needle!((); $($arms)*),
             &mut $slf.emitter,
             |xs, $emitter| match xs {
-                $( $($pattern)* => $code ),*
+                $($arms)*
             }
         )
     };

--- a/src/read_helper.rs
+++ b/src/read_helper.rs
@@ -253,13 +253,13 @@ macro_rules! produce_needle {
 ///
 /// fn after<R: Reader>(slf: &mut Tokenizer<R>) {
 ///     fast_read_char!(slf, emitter, match READ_CHAR {
-///         (Some("<")) => {
+///         Some("<") => {
 ///             todo!()
 ///         }
-///         (Some(x)) => {
+///         Some(x) => {
 ///             todo!()
 ///         }
-///         (None) => {
+///         None => {
 ///             todo!()
 ///         }
 ///     })

--- a/src/read_helper.rs
+++ b/src/read_helper.rs
@@ -99,7 +99,7 @@ impl<R: Reader> ReadHelper<R> {
                 };
 
                 let mut last_i = 0;
-                if last_character_was_cr && xs.starts_with("\n") {
+                if last_character_was_cr && xs.starts_with('\n') {
                     last_i = 1;
                 }
 
@@ -120,7 +120,7 @@ impl<R: Reader> ReadHelper<R> {
                 for x in xs2.chars() {
                     Self::validate_char(emitter, x);
                 }
-                last_character_was_cr = xs.ends_with("\r");
+                last_character_was_cr = xs.ends_with('\r');
                 read_cb(Some(xs2), emitter)
             });
 

--- a/src/read_helper.rs
+++ b/src/read_helper.rs
@@ -215,10 +215,10 @@ macro_rules! produce_needle {
     (($($acc:tt)*); , $($rest:tt)*) => {
         $crate::read_helper::produce_needle!(($($acc)*); $($rest)*)
     };
-    (($($acc:tt)*); => $($rest:tt)*) => {
+    (($($acc:tt)*); => $garbage:expr, $($rest:tt)*) => {
         $crate::read_helper::produce_needle!(($($acc)*); $($rest)*)
     };
-    (($($acc:tt)*); { $($garbage:tt)* } $($rest:tt)*) => {
+    (($($acc:tt)*); => { $($garbage:tt)* } $($rest:tt)*) => {
         $crate::read_helper::produce_needle!(($($acc)*); $($rest)*)
     };
     (($($acc:tt)*); ( $($pattern:tt)* ) $($rest:tt)*) => {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,5 +1,7 @@
+use crate::utils::ctostr;
 use crate::Never;
 use std::io::{self, BufRead, BufReader, Read};
+
 
 /// An object that provides characters to the tokenizer.
 ///
@@ -25,6 +27,64 @@ pub trait Reader {
     /// If the next characters equal to `s`, this function consumes the respective characters from
     /// the input stream and returns `true`. If not, it does nothing and returns `false`.
     fn try_read_string(&mut self, s: &str, case_sensitive: bool) -> Result<bool, Self::Error>;
+
+    /// Read an arbitrary amount of characters up until and including the next character that
+    /// matches an array entry in `needle`.
+    ///
+    /// Repeatedly call `read_cb` with either:
+    ///
+    /// 1. A chunk of consumed characters that does not contain any characters from `needle`. The chunk can be arbitrarily large or small.
+    /// 2. If the next character is included in `needle`, a string with just that character and nothing else.
+    ///
+    /// In other words, case 1 means "we didn't find the needle yet, but here's some read data",
+    /// while case 2 means "we have found the needle".
+    ///
+    /// If `read_cb` is called with `None` (EOF) or a `needle` like in case 2, `read_until` returns
+    /// that call's return value.
+    ///
+    /// The default implementation simply reads one character and calls `read_cb` with that
+    /// character, ignoring the needle entirely. It is recommended to manually implement
+    /// `read_until` if there is any sort of in-memory buffer where `memchr` can be run on.
+    ///
+    /// # Example
+    ///
+    /// Here is how [`StringReader`] behaves:
+    ///
+    /// ```rust
+    /// use html5gum::{Reader, Readable};
+    ///
+    /// let mut reader = "hello world".to_reader();
+    /// let mut eof = false;
+    /// let mut chunks = Vec::new();
+    /// while !eof {
+    ///     reader.read_until(&[' ', 'r'], |xs| {
+    ///         if let Some(xs) = xs {
+    ///             chunks.push(xs.to_owned());
+    ///         } else {
+    ///             eof = true;
+    ///         }
+    ///     });
+    /// }
+    ///
+    /// assert_eq!(chunks, &["hello", " ", "wo", "r", "ld"]);
+    /// ```
+    ///
+    /// The inefficient default implementation produces:
+    ///
+    /// ```text
+    /// ["h", "e", "l", "l", "o", " ", "w", "o", "r", "l", "d"]
+    /// ```
+    fn read_until<F, V>(&mut self, needle: &[char], mut read_cb: F) -> Result<V, Self::Error>
+    where
+        F: FnMut(Option<&str>) -> V,
+    {
+        let _needle = needle;
+
+        match self.read_char()? {
+            Some(x) => Ok(read_cb(Some(ctostr!(x)))),
+            None => Ok(read_cb(None)),
+        }
+    }
 }
 
 /// An object that can be converted into a [`crate::Reader`].
@@ -103,6 +163,32 @@ impl<'a> Reader for StringReader<'a> {
         };
         self.pos += c.len_utf8();
         Ok(Some(c))
+    }
+
+    fn read_until<F, V>(&mut self, needle: &[char], mut read_cb: F) -> Result<V, Self::Error>
+    where
+        F: FnMut(Option<&str>) -> V,
+    {
+        if let Some(input) = self.input.get(self.pos..) {
+            if let Some(needle_pos) = fast_find(needle, input) {
+                if needle_pos == 0 {
+                    let needle = self.cursor.next().unwrap();
+                    self.pos += needle.len_utf8();
+                    Ok(read_cb(Some(ctostr!(needle))))
+                } else {
+                    self.pos += needle_pos;
+                    let (s1, s2) = input.split_at(needle_pos);
+                    self.cursor = s2.chars();
+                    Ok(read_cb(Some(s1)))
+                }
+            } else {
+                self.pos = self.input.len() + 1;
+                self.cursor = "".chars();
+                Ok(read_cb(Some(input)))
+            }
+        } else {
+            Ok(read_cb(None))
+        }
     }
 
     fn try_read_string(&mut self, s1: &str, case_sensitive: bool) -> Result<bool, Self::Error> {
@@ -223,6 +309,30 @@ impl<R: BufRead> Reader for BufReadReader<R> {
 
         Ok(false)
     }
+
+    fn read_until<F, V>(&mut self, needle: &[char], mut read_cb: F) -> Result<V, Self::Error> where F: FnMut(Option<&str>) -> V {
+        let line = self.get_remaining_line()?;
+        let rv;
+        if !line.is_empty() {
+            if let Some(needle_pos) = fast_find(needle, line) {
+                if needle_pos == 0 {
+                    let len = line.chars().next().unwrap().len_utf8();
+                    rv = Ok(read_cb(Some(&line[..len])));
+                    self.line_pos += len;
+                } else {
+                    rv = Ok(read_cb(Some(&line[..needle_pos])));
+                    self.line_pos += needle_pos;
+                }
+            } else {
+                rv = Ok(read_cb(Some(&line)));
+                self.line_pos += line.len();
+            }
+        } else {
+            rv = Ok(read_cb(None));
+        };
+
+        rv
+    }
 }
 
 impl<'a, R: Read + 'a> Readable<'a> for BufReader<R> {
@@ -231,4 +341,20 @@ impl<'a, R: Read + 'a> Readable<'a> for BufReader<R> {
     fn to_reader(self) -> Self::Reader {
         BufReadReader::new(self)
     }
+}
+
+#[inline]
+fn fast_find(needle: &[char], haystack: &str) -> Option<usize> {
+    #[cfg(feature = "memchr")]
+    if needle.iter().all(|x| x.is_ascii()) {
+        if needle.len() == 3 {
+            return memchr::memchr3(needle[0] as u8 , needle[1] as u8, needle[2] as u8, haystack.as_bytes());
+        } else if needle.len() == 2 {
+            return memchr::memchr2(needle[0] as u8 , needle[1] as u8, haystack.as_bytes());
+        } else if needle.len() == 1 {
+            return memchr::memchr(needle[0] as u8, haystack.as_bytes());
+        }
+    }
+
+    haystack.find(needle)
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2,7 +2,6 @@ use crate::utils::ctostr;
 use crate::Never;
 use std::io::{self, BufRead, BufReader, Read};
 
-
 /// An object that provides characters to the tokenizer.
 ///
 /// See [`crate::Tokenizer::new`] for more information.
@@ -310,7 +309,10 @@ impl<R: BufRead> Reader for BufReadReader<R> {
         Ok(false)
     }
 
-    fn read_until<F, V>(&mut self, needle: &[char], mut read_cb: F) -> Result<V, Self::Error> where F: FnMut(Option<&str>) -> V {
+    fn read_until<F, V>(&mut self, needle: &[char], mut read_cb: F) -> Result<V, Self::Error>
+    where
+        F: FnMut(Option<&str>) -> V,
+    {
         let line = self.get_remaining_line()?;
         let rv;
         if !line.is_empty() {
@@ -324,7 +326,7 @@ impl<R: BufRead> Reader for BufReadReader<R> {
                     self.line_pos += needle_pos;
                 }
             } else {
-                rv = Ok(read_cb(Some(&line)));
+                rv = Ok(read_cb(Some(line)));
                 self.line_pos += line.len();
             }
         } else {
@@ -348,9 +350,14 @@ fn fast_find(needle: &[char], haystack: &str) -> Option<usize> {
     #[cfg(feature = "memchr")]
     if needle.iter().all(|x| x.is_ascii()) {
         if needle.len() == 3 {
-            return memchr::memchr3(needle[0] as u8 , needle[1] as u8, needle[2] as u8, haystack.as_bytes());
+            return memchr::memchr3(
+                needle[0] as u8,
+                needle[1] as u8,
+                needle[2] as u8,
+                haystack.as_bytes(),
+            );
         } else if needle.len() == 2 {
-            return memchr::memchr2(needle[0] as u8 , needle[1] as u8, haystack.as_bytes());
+            return memchr::memchr2(needle[0] as u8, needle[1] as u8, haystack.as_bytes());
         } else if needle.len() == 1 {
             return memchr::memchr(needle[0] as u8, haystack.as_bytes());
         }

--- a/src/slow_reader.rs
+++ b/src/slow_reader.rs
@@ -1,0 +1,16 @@
+use crate::Reader;
+
+/// A kind of reader that implements read_until very poorly. Only available in tests
+pub struct SlowReader<R: Reader>(pub R);
+
+impl<R: Reader> Reader for SlowReader<R> {
+    type Error = R::Error;
+
+    fn read_char(&mut self) -> Result<Option<char>, Self::Error> {
+        self.0.read_char()
+    }
+
+    fn try_read_string(&mut self, s: &str, case_sensitive: bool) -> Result<bool, Self::Error> {
+        self.0.try_read_string(s, case_sensitive)
+    }
+}

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -35,12 +35,7 @@ impl<R: Reader, E: Emitter> Tokenizer<R, E> {
             eof: false,
             emitter,
             reader: ReadHelper::new(input.to_reader()),
-            machine_helper: MachineHelper {
-                temporary_buffer: String::new(),
-                character_reference_code: 0,
-                state: State::Data,
-                return_state: None,
-            },
+            machine_helper: MachineHelper::default(),
         }
     }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,43 +1,15 @@
 use crate::machine;
-use crate::utils::{control_pat, noncharacter_pat, surrogate_pat, ControlToken, State};
-use crate::{DefaultEmitter, Emitter, Error, Never, Readable, Reader};
-
-// this is a stack that can hold 0 to 2 Ts
-#[derive(Debug, Default, Clone, Copy)]
-struct Stack2<T: Copy>(Option<(T, Option<T>)>);
-
-impl<T: Copy> Stack2<T> {
-    #[inline]
-    fn push(&mut self, c: T) {
-        self.0 = match self.0 {
-            None => Some((c, None)),
-            Some((c1, None)) => Some((c1, Some(c))),
-            Some((_c1, Some(_c2))) => panic!("stack full!"),
-        }
-    }
-
-    #[inline]
-    fn pop(&mut self) -> Option<T> {
-        let (new_self, rv) = match self.0 {
-            Some((c1, Some(c2))) => (Some((c1, None)), Some(c2)),
-            Some((c1, None)) => (None, Some(c1)),
-            None => (None, None),
-        };
-        self.0 = new_self;
-        rv
-    }
-}
+use crate::machine_helper::MachineHelper;
+use crate::read_helper::ReadHelper;
+use crate::utils::{ControlToken, State};
+use crate::{DefaultEmitter, Emitter, Never, Readable, Reader};
 
 /// A HTML tokenizer. See crate-level docs for basic usage.
 pub struct Tokenizer<R: Reader, E: Emitter = DefaultEmitter> {
     eof: bool,
-    pub(crate) state: State,
     pub(crate) emitter: E,
-    pub(crate) temporary_buffer: String,
-    reader: R,
-    to_reconsume: Stack2<Option<char>>,
-    pub(crate) character_reference_code: u32,
-    pub(crate) return_state: Option<State>,
+    pub(crate) reader: ReadHelper<R>,
+    pub(crate) machine_helper: MachineHelper,
 }
 
 impl<R: Reader> Tokenizer<R> {
@@ -61,13 +33,14 @@ impl<R: Reader, E: Emitter> Tokenizer<R, E> {
     pub fn new_with_emitter<'a, S: Readable<'a, Reader = R>>(input: S, emitter: E) -> Self {
         Tokenizer {
             eof: false,
-            state: State::Data,
             emitter,
-            temporary_buffer: String::new(),
-            to_reconsume: Stack2::default(),
-            reader: input.to_reader(),
-            character_reference_code: 0,
-            return_state: None,
+            reader: ReadHelper::new(input.to_reader()),
+            machine_helper: MachineHelper {
+                temporary_buffer: String::new(),
+                character_reference_code: 0,
+                state: State::Data,
+                return_state: None,
+            },
         }
     }
 
@@ -76,7 +49,7 @@ impl<R: Reader, E: Emitter> Tokenizer<R, E> {
     /// Only available with the `integration-tests` feature which is not public API.
     #[cfg(feature = "integration-tests")]
     pub fn set_state(&mut self, state: State) {
-        self.state = state;
+        self.machine_helper.state = state;
     }
 
     /// Set the statemachine to start/continue in [plaintext
@@ -84,7 +57,7 @@ impl<R: Reader, E: Emitter> Tokenizer<R, E> {
     ///
     /// This tokenizer never gets into that state naturally.
     pub fn set_plaintext_state(&mut self) {
-        self.state = State::PlainText;
+        self.machine_helper.state = State::PlainText;
     }
 
     /// Test-internal function to override internal state.
@@ -93,114 +66,6 @@ impl<R: Reader, E: Emitter> Tokenizer<R, E> {
     #[cfg(feature = "integration-tests")]
     pub fn set_last_start_tag(&mut self, last_start_tag: Option<&str>) {
         self.emitter.set_last_start_tag(last_start_tag);
-    }
-
-    #[inline]
-    pub(crate) fn unread_char(&mut self, c: Option<char>) {
-        self.to_reconsume.push(c);
-    }
-
-    #[inline]
-    fn validate_char(&mut self, c: char) {
-        match c as u32 {
-            surrogate_pat!() => {
-                self.emitter.emit_error(Error::SurrogateInInputStream);
-            }
-            noncharacter_pat!() => {
-                self.emitter.emit_error(Error::NoncharacterInInputStream);
-            }
-            // control without whitespace or nul
-            x @ control_pat!()
-                if !matches!(x, 0x0000 | 0x0009 | 0x000a | 0x000c | 0x000d | 0x0020) =>
-            {
-                self.emitter
-                    .emit_error(Error::ControlCharacterInInputStream);
-            }
-            _ => (),
-        }
-    }
-
-    pub(crate) fn read_char(&mut self) -> Result<Option<char>, R::Error> {
-        let (c_res, reconsumed) = match self.to_reconsume.pop() {
-            Some(c) => (Ok(c), true),
-            None => (self.reader.read_char(), false),
-        };
-
-        let mut c = match c_res {
-            Ok(Some(c)) => c,
-            res => return res,
-        };
-
-        if c == '\r' {
-            c = '\n';
-            let c2 = self.reader.read_char()?;
-            if c2 != Some('\n') {
-                self.unread_char(c2);
-            }
-        }
-
-        if !reconsumed {
-            self.validate_char(c);
-        }
-
-        Ok(Some(c))
-    }
-
-    #[inline]
-    pub(crate) fn try_read_string(
-        &mut self,
-        mut s: &str,
-        case_sensitive: bool,
-    ) -> Result<bool, R::Error> {
-        debug_assert!(!s.is_empty());
-
-        let to_reconsume_bak = self.to_reconsume;
-        let mut chars = s.chars();
-        while let Some(c) = self.to_reconsume.pop() {
-            if let (Some(x), Some(x2)) = (c, chars.next()) {
-                if x == x2 || (!case_sensitive && x.to_ascii_lowercase() == x2.to_ascii_lowercase())
-                {
-                    s = &s[x.len_utf8()..];
-                    continue;
-                }
-            }
-
-            self.to_reconsume = to_reconsume_bak;
-            return Ok(false);
-        }
-
-        self.reader.try_read_string(s, case_sensitive)
-    }
-
-    pub(crate) fn is_consumed_as_part_of_an_attribute(&self) -> bool {
-        matches!(
-            self.return_state,
-            Some(
-                State::AttributeValueDoubleQuoted
-                    | State::AttributeValueSingleQuoted
-                    | State::AttributeValueUnquoted
-            )
-        )
-    }
-
-    pub(crate) fn flush_code_points_consumed_as_character_reference(&mut self) {
-        if self.is_consumed_as_part_of_an_attribute() {
-            self.emitter.push_attribute_value(&self.temporary_buffer);
-            self.temporary_buffer.clear();
-        } else {
-            self.flush_buffer_characters();
-        }
-    }
-
-    pub(crate) fn next_input_character(&mut self) -> Result<Option<char>, R::Error> {
-        let rv = self.read_char()?;
-        self.unread_char(rv);
-        Ok(rv)
-    }
-
-    pub(crate) fn flush_buffer_characters(&mut self) {
-        self.emitter.emit_string(&self.temporary_buffer);
-        self.temporary_buffer.clear();
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -170,3 +170,14 @@ macro_rules! ctostr {
 }
 
 pub(crate) use ctostr;
+
+/// Repeatedly call `f` with chunks of lowercased characters from `s`.
+pub(crate) fn with_lowercase_str(s: &str, mut f: impl FnMut(&str)) {
+    if s.chars().any(|x| x.is_ascii_uppercase()) {
+        for x in s.chars() {
+            f(ctostr!(x.to_ascii_lowercase()))
+        }
+    } else {
+        f(s);
+    }
+}

--- a/tests/test_html5lib.rs
+++ b/tests/test_html5lib.rs
@@ -1,4 +1,6 @@
-use html5gum::{Doctype, EndTag, Error, Reader, StartTag, State, Token, Tokenizer};
+use html5gum::{
+    Doctype, EndTag, Error, Readable, Reader, SlowReader, StartTag, State, Token, Tokenizer,
+};
 use pretty_assertions::assert_eq;
 use serde::{de::Error as _, Deserialize};
 use std::{collections::BTreeMap, fs::File, io::BufReader, path::Path};
@@ -229,6 +231,15 @@ fn run_test(fname: &str, test_i: usize, mut test: Test) {
             test_i,
             &test,
             state.0,
+            Tokenizer::new(SlowReader(test.input.to_reader())),
+            "slow-string",
+        );
+
+        run_test_inner(
+            fname,
+            test_i,
+            &test,
+            state.0,
             Tokenizer::new(&test.input),
             "string",
         );
@@ -240,6 +251,17 @@ fn run_test(fname: &str, test_i: usize, mut test: Test) {
             state.0,
             Tokenizer::new(BufReader::new(test.input.as_bytes())),
             "bufread",
+        );
+
+        run_test_inner(
+            fname,
+            test_i,
+            &test,
+            state.0,
+            Tokenizer::new(SlowReader(
+                BufReader::new(test.input.as_bytes()).to_reader(),
+            )),
+            "slow-bufread",
         );
     }
 }

--- a/tests/test_html5lib.rs
+++ b/tests/test_html5lib.rs
@@ -169,7 +169,6 @@ impl<'de> Deserialize<'de> for ParseErrorInner {
 #[serde(rename_all = "camelCase")]
 struct ParseError {
     code: ParseErrorInner,
-    // TODO: lineno and column?
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
As suggested by @ygg01 in #12, memchr can be used to make state transitions faster. That was not the primary point of the issue though, and not all states make ideal usage of memchr still.

TODO:

- [x] Allow usage of fast_read_char where unread_char is used
- [x] Allow usage of fast_read_char where state is switched in a catch-all branch
- [x] **bug+dangerous**: For the above reason, ScriptData states are currently messed up, html5lib-tests lack coverage!
- [ ] Figure out if we can make the trait a bit nicer
- [ ] Figure out benchmarking situation, just running [hyperlink](https://github.com/untitaker/hyperlink/) on huge folders to test is not really cutting it
- [ ] (stretch) actually port to bytes
- [x] resolve TODOs in code