### PR TITLE
Fuzzing with html5ever

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,3 +1,4 @@
-/in/
-/out/
+/in
+/out
 /target
+/target-afl

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+/in/
+/out/
+/target

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 html5gum = { path = "../" }
+html5gum_old = { version = "*", package = "html5gum" }
 afl = "0.11.0"
 html5ever = "0.25.1"
 pretty_assertions = "1.0.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -6,3 +6,17 @@ edition = "2021"
 [dependencies]
 html5gum = { path = "../" }
 afl = "0.11.0"
+html5ever = "0.25.1"
+pretty_assertions = "1.0.0"
+
+[lib]
+name = "testcase"
+path = "src/testcase.rs"
+
+[[bin]]
+name = "html5gum-fuzz-afl"
+path = "src/main_afl.rs"
+
+[[bin]]
+name = "html5gum-fuzz-cli"
+path = "src/main_cli.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "html5gum-fuzz"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+html5gum = { path = "../" }
+afl = "0.11.0"

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -11,7 +11,7 @@ setup-afl: in
 	CARGO_TARGET_DIR=./target-afl/ cargo afl build --bin html5gum-fuzz-afl
 
 afl: setup-afl
-	CARGO_TARGET_DIR=./target-afl/ AFL_AUTORESUME=1 cargo afl fuzz -i in -o out target-afl/debug/html5gum-fuzz-afl
+	CARGO_TARGET_DIR=./target-afl/ AFL_AUTORESUME=1 cargo afl fuzz $$AFL_OPTS -i in -o out target-afl/debug/html5gum-fuzz-afl
 
 try-afl-crashes:
 	set -e && for f in out/default/crashes/id:*; do \

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -11,10 +11,10 @@ setup-afl: in
 	CARGO_TARGET_DIR=./target-afl/ cargo afl build --bin html5gum-fuzz-afl
 
 afl: setup-afl
-	CARGO_TARGET_DIR=./target-afl/ AFL_AUTORESUME=1 cargo afl fuzz $$AFL_OPTS -i in -o out target-afl/debug/html5gum-fuzz-afl
+	CARGO_TARGET_DIR=./target-afl/ AFL_AUTORESUME=1 cargo afl fuzz $$_AFL_OPTS -i in -o out target-afl/debug/html5gum-fuzz-afl
 
 try-afl-crashes:
-	set -e && for f in out/default/crashes/id:*; do \
+	set -e && for f in out/*/crashes/id:*; do \
 		echo $$f; \
 		$(MAKE) cli < $$f; \
 	done

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -1,0 +1,9 @@
+setup:
+	which cargo-afl || cargo install afl
+	cargo afl build
+	mkdir -p in
+	curl https://www.nytimes.com/ > in/nytimes.html
+	curl https://docs.sentry.io/ > in/sentrydocs.html
+
+run:
+	cargo afl fuzz -i in -o out target/debug/html5gum-fuzz

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -15,7 +15,7 @@ setup-afl: in
 afl: setup-afl
 	CARGO_TARGET_DIR=./target-afl/ AFL_AUTORESUME=1 cargo afl fuzz $$_AFL_OPTS -i in -o out ${AFL_TARGET_BIN}
 
-try-afl-crashes:
+afl-tmin:
 	set -e && for f in out/*/crashes/id:*; do \
 		echo $$f; \
 		if ! $(MAKE) cli < $$f; then \

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -1,3 +1,5 @@
+AFL_TARGET_BIN=target-afl/debug/html5gum-fuzz-afl
+
 clean:
 	rm -rf target target-afl in out
 
@@ -11,12 +13,15 @@ setup-afl: in
 	CARGO_TARGET_DIR=./target-afl/ cargo afl build --bin html5gum-fuzz-afl
 
 afl: setup-afl
-	CARGO_TARGET_DIR=./target-afl/ AFL_AUTORESUME=1 cargo afl fuzz $$_AFL_OPTS -i in -o out target-afl/debug/html5gum-fuzz-afl
+	CARGO_TARGET_DIR=./target-afl/ AFL_AUTORESUME=1 cargo afl fuzz $$_AFL_OPTS -i in -o out ${AFL_TARGET_BIN}
 
 try-afl-crashes:
 	set -e && for f in out/*/crashes/id:*; do \
 		echo $$f; \
-		$(MAKE) cli < $$f; \
+		if ! $(MAKE) cli < $$f; then \
+			afl-tmin -i $$f -o /tmp/html5gum-mintest ${AFL_TARGET_BIN}; \
+			exit 2; \
+		fi \
 	done
 
 cli:

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -15,14 +15,28 @@ setup-afl: in
 afl: setup-afl
 	CARGO_TARGET_DIR=./target-afl/ AFL_AUTORESUME=1 cargo afl fuzz $$_AFL_OPTS -i in -o out ${AFL_TARGET_BIN}
 
-afl-tmin:
-	set -e && for f in out/*/crashes/id:*; do \
+afl-next:
+	set -e && for f in $$(echo out/*/crashes/id:* | sort); do \
 		echo $$f; \
 		if ! $(MAKE) cli < $$f; then \
 			afl-tmin -i $$f -o /tmp/html5gum-mintest ${AFL_TARGET_BIN}; \
+			echo /tmp/html5gum-mintest; \
+			echo ----; \
+			cat -v /tmp/html5gum-mintest; \
+			echo; \
+			echo ----; \
 			exit 2; \
+		else \
+			rm $$f; \
 		fi \
 	done
+
+afl-skip:
+	set -e && for f in $$(echo out/*/crashes/id:* | sort); do \
+		rm $$f; \
+		break; \
+	done
+
 
 cli:
 	cargo run --bin html5gum-fuzz-cli

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -23,7 +23,7 @@ afl-next:
 	set -e && for f in $$(echo out/*/crashes/id:* | sort); do \
 		echo $$f; \
 		if ! $(MAKE) cli < $$f; then \
-			afl-tmin -i $$f -o /tmp/html5gum-mintest ${AFL_TARGET_BIN}; \
+			cargo afl tmin -i $$f -o /tmp/html5gum-mintest ${AFL_TARGET_BIN}; \
 			echo /tmp/html5gum-mintest; \
 			echo ----; \
 			cat -v /tmp/html5gum-mintest; \

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -1,3 +1,7 @@
+export FUZZ_BASIC := 0
+export FUZZ_OLD_HTML5GUM := 0
+export FUZZ_HTML5EVER := 0
+
 AFL_TARGET_BIN=target-afl/debug/html5gum-fuzz-afl
 
 clean:

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -1,9 +1,23 @@
-setup:
-	which cargo-afl || cargo install afl
-	cargo afl build
+clean:
+	rm -rf target target-afl in out
+
+in:
 	mkdir -p in
 	curl https://www.nytimes.com/ > in/nytimes.html
 	curl https://docs.sentry.io/ > in/sentrydocs.html
 
-run:
-	cargo afl fuzz -i in -o out target/debug/html5gum-fuzz
+setup-afl: in
+	which cargo-afl || cargo install afl
+	CARGO_TARGET_DIR=./target-afl/ cargo afl build --bin html5gum-fuzz-afl
+
+afl: setup-afl
+	CARGO_TARGET_DIR=./target-afl/ AFL_AUTORESUME=1 cargo afl fuzz -i in -o out target-afl/debug/html5gum-fuzz-afl
+
+try-afl-crashes:
+	set -e && for f in out/default/crashes/id:*; do \
+		echo $$f; \
+		$(MAKE) cli < $$f; \
+	done
+
+cli:
+	cargo run --bin html5gum-fuzz-cli

--- a/fuzz/src/main.rs
+++ b/fuzz/src/main.rs
@@ -1,8 +1,0 @@
-fn main() {
-    afl::fuzz!(|data: &[u8]| {
-        if let Ok(s) = std::str::from_utf8(data) {
-            for token in html5gum::Tokenizer::new(s).infallible() {
-            }
-        }
-    });
-}

--- a/fuzz/src/main.rs
+++ b/fuzz/src/main.rs
@@ -1,0 +1,8 @@
+fn main() {
+    afl::fuzz!(|data: &[u8]| {
+        if let Ok(s) = std::str::from_utf8(data) {
+            for token in html5gum::Tokenizer::new(s).infallible() {
+            }
+        }
+    });
+}

--- a/fuzz/src/main_afl.rs
+++ b/fuzz/src/main_afl.rs
@@ -1,0 +1,9 @@
+use testcase::run;
+
+fn main() {
+    afl::fuzz!(|data: &[u8]| {
+        if let Ok(s) = std::str::from_utf8(data) {
+            run(s);
+        }
+    });
+}

--- a/fuzz/src/main_cli.rs
+++ b/fuzz/src/main_cli.rs
@@ -1,0 +1,9 @@
+use std::io::Read;
+
+use testcase::run;
+
+fn main() {
+    let mut input = String::new();
+    std::io::stdin().lock().read_to_string(&mut input).unwrap();
+    run(&input);
+}

--- a/fuzz/src/testcase.rs
+++ b/fuzz/src/testcase.rs
@@ -20,11 +20,15 @@ pub fn run(s: &str) {
     if env::var("FUZZ_OLD_HTML5GUM").unwrap() == "1" {
         let reference_tokenizer = html5gum_old::Tokenizer::new(s).infallible();
         let testing_tokenizer = html5gum::Tokenizer::new(s).infallible();
+        let mut testing_tokens = Vec::new();
+        let mut reference_tokens = Vec::new();
         for (a, b) in testing_tokenizer.zip(reference_tokenizer) {
             // Check equality of two different versions of Token by... stringifying them
-            assert_eq!(format!("{:?}", a), format!("{:?}", b));
+            testing_tokens.push(format!("{:?}", a));
+            reference_tokens.push(format!("{:?}", b));
         }
 
+        assert_eq!(testing_tokens, reference_tokens);
         did_anything = true;
     }
 

--- a/fuzz/src/testcase.rs
+++ b/fuzz/src/testcase.rs
@@ -34,7 +34,10 @@ impl<R: Reader, E: Emitter<Token = Token>> html5ever::tokenizer::TokenSink for T
         reference_token: html5ever::tokenizer::Token,
         _line_number: u64,
     ) -> TokenSinkResult<Self::Handle> {
-        if matches!(reference_token, Token2::NullCharacterToken | Token2::ParseError(_) | Token2::CharacterTokens(_)) {
+        if matches!(
+            reference_token,
+            Token2::NullCharacterToken | Token2::ParseError(_) | Token2::CharacterTokens(_)
+        ) {
             // TODO
             return TokenSinkResult::Continue;
         };
@@ -62,9 +65,21 @@ impl<R: Reader, E: Emitter<Token = Token>> html5ever::tokenizer::TokenSink for T
                 assert_eq!(comment, comment2.as_ref());
             }
             (Some(Token::Doctype(doctype)), Token2::DoctypeToken(doctype2)) => {
-                assert_eq!(doctype.name, doctype2.name.map(|x| x.as_ref().to_owned()).unwrap_or_default());
-                assert_eq!(doctype.public_identifier, doctype2.public_id.map(|x| x.as_ref().to_owned()));
-                assert_eq!(doctype.system_identifier, doctype2.system_id.map(|x| x.as_ref().to_owned()));
+                assert_eq!(
+                    doctype.name,
+                    doctype2
+                        .name
+                        .map(|x| x.as_ref().to_owned())
+                        .unwrap_or_default()
+                );
+                assert_eq!(
+                    doctype.public_identifier,
+                    doctype2.public_id.map(|x| x.as_ref().to_owned())
+                );
+                assert_eq!(
+                    doctype.system_identifier,
+                    doctype2.system_id.map(|x| x.as_ref().to_owned())
+                );
                 assert_eq!(doctype.force_quirks, doctype2.force_quirks);
             }
             (a, b) => panic!("5gum: {:?}\n5ever: {:?}", a, b),

--- a/fuzz/src/testcase.rs
+++ b/fuzz/src/testcase.rs
@@ -1,0 +1,75 @@
+use html5ever::buffer_queue::BufferQueue;
+use html5ever::tendril::format_tendril;
+use html5ever::tokenizer::{TagKind, Token as Token2, TokenSinkResult, TokenizerResult};
+use html5gum::{Emitter, Reader, Token};
+
+use pretty_assertions::assert_eq;
+
+pub fn run(s: &str) {
+    let mut reference_tokenizer = html5ever::tokenizer::Tokenizer::new(
+        TokenSink {
+            testing_tokenizer: html5gum::Tokenizer::new(s),
+        },
+        Default::default(),
+    );
+    let mut queue = BufferQueue::new();
+    queue.push_back(format_tendril!("{}", s));
+
+    assert!(matches!(
+        reference_tokenizer.feed(&mut queue),
+        TokenizerResult::Done
+    ));
+    reference_tokenizer.end();
+}
+
+struct TokenSink<R: Reader, E: Emitter> {
+    testing_tokenizer: html5gum::Tokenizer<R, E>,
+}
+
+impl<R: Reader, E: Emitter<Token = Token>> html5ever::tokenizer::TokenSink for TokenSink<R, E> {
+    type Handle = ();
+
+    fn process_token(
+        &mut self,
+        reference_token: html5ever::tokenizer::Token,
+        _line_number: u64,
+    ) -> TokenSinkResult<Self::Handle> {
+        if matches!(reference_token, Token2::NullCharacterToken | Token2::ParseError(_) | Token2::CharacterTokens(_)) {
+            // TODO
+            return TokenSinkResult::Continue;
+        };
+        let token = loop {
+            let token = self.testing_tokenizer.next();
+            if matches!(token, Some(Ok(Token::Error(_) | Token::String(_)))) {
+                // TODO
+                continue;
+            }
+
+            break token.map(|x| x.unwrap());
+        };
+
+        match (token, reference_token) {
+            (Some(Token::StartTag(tag)), Token2::TagToken(tag2)) => {
+                assert_eq!(tag2.kind, TagKind::StartTag);
+                assert_eq!(tag.name, tag2.name.as_ref());
+            }
+            (Some(Token::EndTag(tag)), Token2::TagToken(tag2)) => {
+                assert_eq!(tag2.kind, TagKind::EndTag);
+                assert_eq!(tag.name, tag2.name.as_ref());
+            }
+            (None, Token2::EOFToken) => {}
+            (Some(Token::Comment(comment)), Token2::CommentToken(comment2)) => {
+                assert_eq!(comment, comment2.as_ref());
+            }
+            (Some(Token::Doctype(doctype)), Token2::DoctypeToken(doctype2)) => {
+                assert_eq!(doctype.name, doctype2.name.map(|x| x.as_ref().to_owned()).unwrap_or_default());
+                assert_eq!(doctype.public_identifier, doctype2.public_id.map(|x| x.as_ref().to_owned()));
+                assert_eq!(doctype.system_identifier, doctype2.system_id.map(|x| x.as_ref().to_owned()));
+                assert_eq!(doctype.force_quirks, doctype2.force_quirks);
+            }
+            (a, b) => panic!("5gum: {:?}\n5ever: {:?}", a, b),
+        }
+
+        TokenSinkResult::Continue
+    }
+}


### PR DESCRIPTION
Related:

https://github.com/html5lib/html5lib-tests/pull/140
https://github.com/servo/html5ever/issues/459

Run html5ever's tokenizer tandem with html5gum within afl to find bugs and behavior differences. Blocked on fixing some testcase failures in html5ever, see above.

Alternatively we can fuzz html5gum together with released html5gum? This could help validating #18 