### PR TITLE
Added rust-toolchain file and set to stable

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+# This prevents contributors using non-stable std APIs which won't build on stable channel.
+# Other channels is still able to build html5gum by overriding it on command line.
+channel = "stable"


### PR DESCRIPTION
This makes sure anyone won't accidentally use a different Rust version, e.g. nightly, when developing.