### PR TITLE
use arrayvec::ArrayVec instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ default = ["jetscii"]
 integration-tests = []
 
 [dependencies]
+arrayvec = "0.7.2"
 jetscii = { version = "0.5.1", optional = true }
 
 [[bench]]

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1,29 +1,18 @@
-/// This is basically like the arrayvec crate, except crappier, only the subset I need and
-/// therefore without unsafe Rust.
+/// Similar to [`arrayvec::ArrayVec`], but only has limited capabilities that we need.
+///
+/// [`arrayvec::ArrayVec`]: https://docs.rs/arrayvec/latest/arrayvec/struct.ArrayVec.html
+pub(crate) struct ArrayVec<T, const CAP: usize>(arrayvec::ArrayVec<T, CAP>);
 
-pub struct ArrayVec<T: Copy, const CAP: usize> {
-    content: [T; CAP],
-    len: usize,
-}
-
-impl<T: Copy, const CAP: usize> ArrayVec<T, CAP> {
-    pub fn new(filler_item: T) -> Self {
-        // filler_item is there to avoid usage of MaybeUninit, and can literally be anything at
-        // all.
-        ArrayVec {
-            content: [filler_item; CAP],
-            len: 0,
-        }
+impl<T, const CAP: usize> ArrayVec<T, CAP> {
+    pub(crate) fn new() -> Self {
+        Self(arrayvec::ArrayVec::new())
     }
 
-    pub fn push(&mut self, item: T) {
-        self.content[self.len] = item;
-        self.len += 1;
+    pub(crate) fn push(&mut self, element: T) {
+        self.0.push(element);
     }
 
-    pub fn drain(&mut self) -> &[T] {
-        let rv = &self.content[..self.len];
-        self.len = 0;
-        rv
+    pub(crate) fn drain(&mut self) -> arrayvec::Drain<T, CAP> {
+        self.0.drain(0..self.0.len())
     }
 }

--- a/src/char_validator.rs
+++ b/src/char_validator.rs
@@ -1,16 +1,18 @@
 use crate::arrayvec::ArrayVec;
 use crate::{Emitter, Error};
 
+const DEF_CAP: usize = 3;
+
 pub(crate) struct CharValidator {
     last_4_bytes: u32,
-    character_error: ArrayVec<Error, 3>,
+    character_error: ArrayVec<Error, DEF_CAP>,
 }
 
 impl Default for CharValidator {
     fn default() -> Self {
         CharValidator {
             last_4_bytes: 0,
-            character_error: ArrayVec::new(Error::EofInTag),
+            character_error: ArrayVec::<Error, DEF_CAP>::new(),
         }
     }
 }
@@ -47,7 +49,7 @@ impl CharValidator {
 
     pub fn flush_character_error<E: Emitter>(&mut self, emitter: &mut E) {
         for e in self.character_error.drain() {
-            emitter.emit_error(*e);
+            emitter.emit_error(e);
         }
     }
 


### PR DESCRIPTION
Added a wrapper type `html5gum::arrayvec::ArrayVec` which
in turn uses `arrayvec::ArrayVec` but only exposes the following
interface:
- `new() -> html5gum::arrayvec::ArrayVec<T, CAP>`
- `push(&mut html5gum::arrayvec::ArrayVec<T, CAP>)`
- `drain(&mut html5gum::arrayvec::ArrayVec<T, CAP>) -> arrayvec::Drain<T, CAP>`

closes #32