### PR TITLE
allow user to define buffer of IoReader

### DIFF
--- a/src/machine_helper.rs
+++ b/src/machine_helper.rs
@@ -4,6 +4,7 @@ use crate::Emitter;
 
 #[derive(Debug)]
 pub(crate) struct MachineHelper {
+    // XXX: allocation that cannot be controlled/reused by the user
     pub(crate) temporary_buffer: Vec<u8>,
     pub(crate) character_reference_code: u32,
     pub(crate) state: State,


### PR DESCRIPTION
html5gum's priorities are with programs that need to parse many
independent html documents per second (i.e. hyperlink)

for that purpose it makes sense to be able to reuse buffers, even though
in the case of hyperlink it doesn't bring any performance
improvement

The temporary_buffer in machine_helper should probably also be
reevaluated at some point.
