### PR TITLE
[breaking]: Rename DefaultEmitter::switch_states

### DIFF
--- a/examples/tokenize_with_state_switches.rs
+++ b/examples/tokenize_with_state_switches.rs
@@ -19,7 +19,7 @@ use html5gum::{DefaultEmitter, IoReader, Tokenizer};
 
 fn main() {
     let mut emitter = DefaultEmitter::default();
-    emitter.switch_states(true);
+    emitter.naively_switch_states(true);
 
     let reader = IoReader::new(std::io::stdin().lock());
 

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -359,15 +359,15 @@ pub struct DefaultEmitter {
     current_attribute: Option<(HtmlString, HtmlString)>,
     seen_attributes: BTreeSet<HtmlString>,
     emitted_tokens: VecDeque<Token>,
-    switch_states: bool,
+    naively_switch_states: bool,
 }
 
 impl DefaultEmitter {
     /// Whether to use [`naive_next_state`] to switch states automatically.
     ///
     /// The default is off.
-    pub fn switch_states(&mut self, yes: bool) {
-        self.switch_states = yes;
+    pub fn naively_switch_states(&mut self, yes: bool) {
+        self.naively_switch_states = yes;
     }
 
     fn emit_token(&mut self, token: Token) {
@@ -468,7 +468,7 @@ impl Emitter for DefaultEmitter {
             _ => debug_assert!(false),
         }
         self.emit_token(token);
-        if self.switch_states {
+        if self.naively_switch_states {
             naive_next_state(&self.last_start_tag)
         } else {
             None


### PR DESCRIPTION
Just to further highlight that this method isn't completely sound.

See https://github.com/untitaker/html5gum/issues/11#issuecomment-1674377059.