### PR TITLE
Update and link G.U.M. acronym

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ looks like in practice.
 
 Why is this library called `html5gum`?
 
-* G.U.M: **G**iant **U**nreadable **M**atch-statement
+* G.U.M: [**G**iant **U**nreadable **M**achine][src/machine.rs]
 
 * \<insert "how it feels to <s>chew 5 gum</s> _parse HTML_" meme here\>
 
@@ -116,3 +116,4 @@ Licensed under the MIT license, see [`./LICENSE`][LICENSE].
 [LICENSE]: ./LICENSE
 [examples/tokenize_with_state_switches.rs]: ./examples/tokenize_with_state_switches.rs
 [examples/custom_emitter.rs]: ./examples/custom_emitter.rs
+[src/machine.rs]: ./src/machine.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![doc = concat!("[LICENSE]: ", blob_url_prefix!(), "LICENSE")]
 #![doc = concat!("[examples/tokenize_with_state_switches.rs]: ", blob_url_prefix!(), "examples/tokenize_with_state_switches.rs")]
 #![doc = concat!("[examples/custom_emitter.rs]: ", blob_url_prefix!(), "examples/custom_emitter.rs")]
+#![doc = concat!("[src/machine.rs]: ", blob_url_prefix!(), "src/machine.rs")]
 #![doc = include_str!("../README.md")]
 //
 #![warn(clippy::all)]


### PR DESCRIPTION
Since d6a0a3ee1f2e155560839ab5c7bd489edfc9c209
it's no longer one single giant match block.