### PR TITLE
Prevent Pwn Requests

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   benchmark:
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     name: Benchmark
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This change is to help prevent malicious pull requests. This is probably my fault due to bad advice in the past. I'm sorry!
I have written update docs on how to better handle pull requests and pull requests from forks here: https://bencher.dev/docs/how-to/github-actions/