### PR TITLE
Test against html5lib-tests errors positions

### DIFF
--- a/src/emitters/callback.rs
+++ b/src/emitters/callback.rs
@@ -357,6 +357,7 @@ where
 
     #[inline]
     fn move_position(&mut self, offset: isize) {
+        crate::utils::trace_log!("callbacks: move_position, current={:?}, offset={}", self.emitter_state.position, offset);
         self.emitter_state.position = self.emitter_state.position.offset(offset);
     }
 
@@ -372,6 +373,7 @@ where
     }
 
     fn emit_error(&mut self, error: Error) {
+        crate::utils::trace_log!("callbacks: error, position={:?}", self.emitter_state.position);
         self.callback_state.emit_event(
             CallbackEvent::Error(error),
             Span {

--- a/src/emitters/default.rs
+++ b/src/emitters/default.rs
@@ -32,7 +32,11 @@ impl<S: SpanBound> Callback<Token<S>, S> for OurCallback<S> {
                 match self.attribute_map.entry(name.to_owned().into()) {
                     Entry::Occupied(_) => Some(Token::Error(Spanned {
                         value: Error::DuplicateAttribute,
-                        span,
+                        span: {
+                            let mut span = span;
+                            span.end = span.end.offset(1);
+                            span
+                        },
                     })),
                     Entry::Vacant(vacant) => {
                         self.attribute_name.extend(name);

--- a/src/emitters/default.rs
+++ b/src/emitters/default.rs
@@ -19,7 +19,7 @@ struct OurCallback<S: SpanBound> {
 
 impl<S: SpanBound> Callback<Token<S>, S> for OurCallback<S> {
     fn handle_event(&mut self, event: CallbackEvent<'_>, span: Span<S>) -> Option<Token<S>> {
-        crate::utils::trace_log!("event: {:?}", event);
+        crate::utils::trace_log!("event: {:?}, span={:?}", event, span);
         match event {
             CallbackEvent::OpenStartTag { name } => {
                 self.tag_name.clear();
@@ -204,4 +204,50 @@ pub enum Token<S: SpanBound = ()> {
     /// Can be skipped over, the tokenizer is supposed to recover from the error and continues with
     /// more tokens afterward.
     Error(Spanned<Error, S>),
+}
+
+impl<S: SpanBound> Token<S> {
+    /// Map the span type to another span type using the provided function.
+    pub fn map_span<T: SpanBound>(self, mut f: impl FnMut(Span<S>) -> Span<T>) -> Token<T> {
+        match self {
+            Token::StartTag(tag) => Token::StartTag(StartTag {
+                self_closing: tag.self_closing,
+                name: tag.name,
+                attributes: tag
+                    .attributes
+                    .into_iter()
+                    .map(|(k, v)| {
+                        (
+                            k,
+                            Spanned {
+                                value: v.value,
+                                span: f(v.span),
+                            },
+                        )
+                    })
+                    .collect(),
+                span: f(tag.span),
+            }),
+            Token::EndTag(tag) => Token::EndTag(EndTag {
+                name: tag.name,
+                span: f(tag.span),
+            }),
+            Token::String(s) => Token::String(Spanned {
+                value: s.value,
+                span: f(s.span),
+            }),
+            Token::Comment(c) => Token::Comment(Spanned {
+                value: c.value,
+                span: f(c.span),
+            }),
+            Token::Doctype(d) => Token::Doctype(Spanned {
+                value: d.value,
+                span: f(d.span),
+            }),
+            Token::Error(e) => Token::Error(Spanned {
+                value: e.value,
+                span: f(e.span),
+            }),
+        }
+    }
 }

--- a/src/emitters/default.rs
+++ b/src/emitters/default.rs
@@ -30,9 +30,9 @@ impl<S: SpanBound> Callback<Token<S>, S> for OurCallback<S> {
             CallbackEvent::AttributeName { name } => {
                 self.attribute_name.clear();
                 match self.attribute_map.entry(name.to_owned().into()) {
-                    Entry::Occupied(old) => Some(Token::Error(Spanned {
+                    Entry::Occupied(_) => Some(Token::Error(Spanned {
                         value: Error::DuplicateAttribute,
-                        span: old.get().span,
+                        span,
                     })),
                     Entry::Vacant(vacant) => {
                         self.attribute_name.extend(name);

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -2021,6 +2021,9 @@ pub(crate) mod states {
     });
 
     define_state!(NumericCharacterReferenceEnd, slf, {
+        // html5lib-tests expect that errors are reported one position after ";" has been read.
+        // temporarily move forward, report the error, then move back.
+        slf.emitter.move_position(1);
         match slf.machine_helper.character_reference_code {
             0x00 => {
                 error!(slf, Error::NullCharacterReference);
@@ -2076,6 +2079,8 @@ pub(crate) mod states {
             }
             _ => (),
         }
+
+        slf.emitter.move_position(-1);
 
         slf.machine_helper.temporary_buffer.clear();
         slf.machine_helper.temporary_buffer.extend(

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -174,7 +174,7 @@ pub(crate) mod states {
                     eof!()
                 }
                 c @ Some(_) => {
-                    error!(slf, Error::InvalidFirstCharacterOfTagName);
+                    error_immediate!(slf, Error::InvalidFirstCharacterOfTagName);
                     slf.emitter.emit_string(b"<");
                     reconsume_in!(slf, c, Data)
                 }
@@ -200,7 +200,7 @@ pub(crate) mod states {
                     eof!()
                 }
                 Some(x) => {
-                    error!(slf, Error::InvalidFirstCharacterOfTagName);
+                    error_immediate!(slf, Error::InvalidFirstCharacterOfTagName);
                     slf.emitter.init_comment();
                     reconsume_in!(slf, Some(x), BogusComment)
                 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -85,18 +85,13 @@ impl<R: Reader, E: Emitter> Tokenizer<R, E> {
             .reader
             .read_byte(&mut self.validator, &mut self.emitter)?;
 
-        if res.is_some() {
-            self.emitter.move_position(1);
-        }
-
+        self.emitter.move_position(1);
         Ok(res)
     }
 
     #[inline(always)]
     pub(crate) fn unread_byte(&mut self, c: Option<u8>) {
-        if c.is_some() {
-            self.emitter.move_position(-1);
-        }
+        self.emitter.move_position(-1);
         self.reader.unread_byte(c);
     }
 
@@ -112,6 +107,8 @@ impl<R: Reader, E: Emitter> Tokenizer<R, E> {
 
         if let Some(res) = &res {
             emitter.move_position(res.len() as isize);
+        } else {
+            emitter.move_position(1);
         }
 
         Ok(res)

--- a/tests/html5lib_tokenizer.rs
+++ b/tests/html5lib_tokenizer.rs
@@ -318,7 +318,7 @@ impl TestCase {
             let token = token.unwrap();
 
             if let Token::Error(e) = &token {
-                let (line, col) = if let Some((line, col)) = position_to_line_col(input, e.span.start)
+                let (line, col) = if let Some((line, col)) = position_to_line_col(input, e.span.end)
                 {
                     (Some(line), Some(col))
                 } else {

--- a/tests/html5lib_tokenizer.rs
+++ b/tests/html5lib_tokenizer.rs
@@ -1,8 +1,8 @@
 use std::{collections::BTreeMap, fs::File, io::BufReader, path::Path};
 
 use html5gum::{
-    Doctype, EndTag, Error, IoReader, Readable, Reader, Span, Spanned, StartTag, State, Token,
-    Tokenizer,
+    DefaultEmitter, Doctype, EndTag, Error, IoReader, Readable, Reader, Span, Spanned, StartTag,
+    State, Token, Tokenizer,
 };
 
 use html5gum::testutils::{trace_log, SlowReader};
@@ -13,6 +13,28 @@ use pretty_assertions::assert_eq;
 use serde::{de::Error as _, Deserialize};
 
 mod testutils;
+
+/// Convert a byte position to line and column numbers (1-indexed)
+fn position_to_line_col(input: &[u8], position: usize) -> Option<(usize, usize)> {
+    let mut line = 1;
+    let mut col = 0;
+
+    for i in 0..=input.len() {
+        if i >= position {
+            break
+        }
+
+        let byte = input.get(i); // None = EOF
+        if byte == Some(&b'\n') {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+
+    Some((line, col))
+}
 
 #[derive(Clone)]
 struct ExpectedOutputTokens(Vec<Token<()>>);
@@ -216,6 +238,10 @@ impl<'de> Deserialize<'de> for ParseErrorInner {
 #[serde(rename_all = "camelCase")]
 struct ParseError {
     code: ParseErrorInner,
+    #[serde(default)]
+    line: Option<usize>,
+    #[serde(default)]
+    col: Option<usize>,
 }
 
 #[derive(Deserialize)]
@@ -243,19 +269,45 @@ impl TestCase {
             let string = self.declaration.input.0.as_slice();
 
             match self.reader_type {
-                ReaderType::String => self.run_inner(Tokenizer::new(string.to_reader())),
+                ReaderType::String => self.run_inner(
+                    Tokenizer::new_with_emitter(
+                        string.to_reader(),
+                        DefaultEmitter::<usize>::new_with_span(),
+                    ),
+                    string,
+                ),
                 ReaderType::SlowString => {
-                    self.run_inner(Tokenizer::new(SlowReader(string.to_reader())));
+                    self.run_inner(
+                        Tokenizer::new_with_emitter(
+                            SlowReader(string.to_reader()),
+                            DefaultEmitter::<usize>::new_with_span(),
+                        ),
+                        string,
+                    );
                 }
-                ReaderType::BufRead => self.run_inner(Tokenizer::new(IoReader::new(string))),
-                ReaderType::SlowBufRead => self.run_inner(Tokenizer::new(SlowReader(
-                    IoReader::new(string).to_reader(),
-                ))),
+                ReaderType::BufRead => self.run_inner(
+                    Tokenizer::new_with_emitter(
+                        IoReader::new(string),
+                        DefaultEmitter::<usize>::new_with_span(),
+                    ),
+                    string,
+                ),
+                ReaderType::SlowBufRead => self.run_inner(
+                    Tokenizer::new_with_emitter(
+                        SlowReader(IoReader::new(string).to_reader()),
+                        DefaultEmitter::<usize>::new_with_span(),
+                    ),
+                    string,
+                ),
             }
         })
     }
 
-    fn run_inner<R: Reader>(&self, mut tokenizer: Tokenizer<R>) {
+    fn run_inner<R: Reader>(
+        &self,
+        mut tokenizer: Tokenizer<R, DefaultEmitter<usize>>,
+        input: &[u8],
+    ) {
         tokenizer.set_state(self.state);
         tokenizer.set_last_start_tag(self.declaration.last_start_tag.as_deref());
 
@@ -265,17 +317,40 @@ impl TestCase {
         for token in tokenizer {
             let token = token.unwrap();
 
-            if let Token::Error(e) = token {
+            if let Token::Error(e) = &token {
+                let (line, col) = if let Some((line, col)) = position_to_line_col(input, e.span.start)
+                {
+                    (Some(line), Some(col))
+                } else {
+                    (None, None)
+                };
                 actual_errors.push(ParseError {
-                    code: ParseErrorInner(*e),
+                    code: ParseErrorInner(**e),
+                    line,
+                    col,
                 });
             } else {
-                actual_tokens.push(token);
+                actual_tokens.push(token.map_span(|_| Span::DUMMY));
             }
         }
 
         assert_eq!(actual_tokens, self.declaration.output.0);
-        assert_eq!(actual_errors, self.declaration.errors);
+
+        let actual_errors_for_comparison: Vec<ParseError> = actual_errors
+            .iter()
+            .cloned()
+            .zip(self.declaration.errors.iter())
+            .map(|(actual, expected)| ParseError {
+                code: actual.code,
+                // Only include line/col if expected has them (otherwise set to None for
+                // comparison)
+                line: expected.line.and(actual.line),
+                col: expected.col.and(actual.col),
+            })
+            .collect();
+
+        assert_eq!(actual_errors_for_comparison, self.declaration.errors);
+        assert_eq!(actual_errors.len(), self.declaration.errors.len());
     }
 }
 

--- a/tests/html5lib_tokenizer.rs
+++ b/tests/html5lib_tokenizer.rs
@@ -14,11 +14,6 @@ use serde::{de::Error as _, Deserialize};
 
 mod testutils;
 
-// https://github.com/html5lib/html5lib-tests/issues/125
-const TESTCASES_WITH_BAD_ERROR_POS: &[&str] = &[
-    "test2.test:Numeric entity representing the NUL character",
-];
-
 /// Convert a byte position to line and column numbers (1-indexed)
 fn position_to_line_col(input: &[u8], position: usize) -> Option<(usize, usize)> {
     let mut line = 1;
@@ -341,10 +336,7 @@ impl TestCase {
 
         assert_eq!(actual_tokens, self.declaration.output.0);
 
-        let mut expected_errors = self.declaration.errors.clone();
-        assert_eq!(actual_errors.len(), expected_errors.len());
-
-        let mut actual_errors_for_comparison: Vec<ParseError> = actual_errors
+        let actual_errors_for_comparison: Vec<ParseError> = actual_errors
             .iter()
             .cloned()
             .zip(self.declaration.errors.iter())
@@ -357,18 +349,8 @@ impl TestCase {
             })
             .collect();
 
-        if TESTCASES_WITH_BAD_ERROR_POS.contains(&format!("{}:{}", self.filename, self.declaration.description).as_str()) {
-            assert!(actual_errors_for_comparison != expected_errors);
-
-            for (actual, expected) in actual_errors_for_comparison.iter_mut().zip(expected_errors.iter_mut()) {
-                actual.line = None;
-                actual.col = None;
-                expected.line = None;
-                expected.col = None;
-            }
-        }
-
-        assert_eq!(actual_errors_for_comparison, expected_errors);
+        assert_eq!(actual_errors_for_comparison, self.declaration.errors);
+        assert_eq!(actual_errors.len(), self.declaration.errors.len());
     }
 }
 

--- a/tests/html5lib_tokenizer.rs
+++ b/tests/html5lib_tokenizer.rs
@@ -14,18 +14,22 @@ use serde::{de::Error as _, Deserialize};
 
 mod testutils;
 
-/// Convert a byte position to line and column numbers (1-indexed)
+/// Convert a byte position to *character-based* line and column numbers (1-indexed)
 fn position_to_line_col(input: &[u8], position: usize) -> Option<(usize, usize)> {
     let mut line = 1;
     let mut col = 0;
 
-    for i in 0..=input.len() {
+    let char_indices_with_eof =
+        std::str::from_utf8(input).unwrap()
+        .char_indices().map(|(i, c)| (i, Some(c)))
+        .chain(Some((input.len(), None)));
+
+    for (i, character) in char_indices_with_eof{
         if i >= position {
             break
         }
 
-        let byte = input.get(i); // None = EOF
-        if byte == Some(&b'\n') {
+        if character == Some('\n') {
             line += 1;
             col = 0;
         } else {

--- a/tests/html5lib_tokenizer.rs
+++ b/tests/html5lib_tokenizer.rs
@@ -14,6 +14,11 @@ use serde::{de::Error as _, Deserialize};
 
 mod testutils;
 
+// https://github.com/html5lib/html5lib-tests/issues/125
+const TESTCASES_WITH_BAD_ERROR_POS: &[&str] = &[
+    "test2.test:Numeric entity representing the NUL character",
+];
+
 /// Convert a byte position to line and column numbers (1-indexed)
 fn position_to_line_col(input: &[u8], position: usize) -> Option<(usize, usize)> {
     let mut line = 1;
@@ -336,7 +341,10 @@ impl TestCase {
 
         assert_eq!(actual_tokens, self.declaration.output.0);
 
-        let actual_errors_for_comparison: Vec<ParseError> = actual_errors
+        let mut expected_errors = self.declaration.errors.clone();
+        assert_eq!(actual_errors.len(), expected_errors.len());
+
+        let mut actual_errors_for_comparison: Vec<ParseError> = actual_errors
             .iter()
             .cloned()
             .zip(self.declaration.errors.iter())
@@ -349,8 +357,18 @@ impl TestCase {
             })
             .collect();
 
-        assert_eq!(actual_errors_for_comparison, self.declaration.errors);
-        assert_eq!(actual_errors.len(), self.declaration.errors.len());
+        if TESTCASES_WITH_BAD_ERROR_POS.contains(&format!("{}:{}", self.filename, self.declaration.description).as_str()) {
+            assert!(actual_errors_for_comparison != expected_errors);
+
+            for (actual, expected) in actual_errors_for_comparison.iter_mut().zip(expected_errors.iter_mut()) {
+                actual.line = None;
+                actual.col = None;
+                expected.line = None;
+                expected.col = None;
+            }
+        }
+
+        assert_eq!(actual_errors_for_comparison, expected_errors);
     }
 }
 


### PR DESCRIPTION
errors positions are not part of the spec, but we can try to be similar to other parsers. that said, the error positions in html5lib-tests seem somewhat internally inconsistent.