### PR TITLE
Send `CallbackEmitter` events in the correct order

### DIFF
--- a/examples/callback_emitter.rs
+++ b/examples/callback_emitter.rs
@@ -53,3 +53,53 @@ fn basic() {
 
     assert_eq!(tokens, vec!["foo".to_owned()]);
 }
+
+#[test]
+fn round_trip() {
+    let mut rt = Vec::new();
+    let emitter = CallbackEmitter::new(|event: CallbackEvent<'_>, _: html5gum::Span<()>| {
+        match event {
+            CallbackEvent::OpenStartTag { name } => {
+                rt.push(b'<');
+                rt.extend(name);
+            }
+            CallbackEvent::AttributeName { name } => {
+                rt.push(b' ');
+                rt.extend(name);
+            }
+            CallbackEvent::AttributeValue { value } => {
+                rt.push(b'=');
+                rt.push(b'"');
+                rt.extend(value);
+                rt.push(b'"');
+            }
+            CallbackEvent::String { value } => {
+                rt.extend(value);
+            }
+            CallbackEvent::CloseStartTag { self_closing } => {
+                if self_closing {
+                    rt.push(b'/');
+                }
+                rt.push(b'>');
+            }
+            CallbackEvent::EndTag { name } => {
+                rt.extend(b"</");
+                rt.extend(name);
+                rt.push(b'>');
+            }
+            CallbackEvent::Comment { value } => {
+                rt.extend(b"<!--");
+                rt.extend(value);
+                rt.extend(b"-->");
+            }
+            CallbackEvent::Doctype { .. } => {}
+            CallbackEvent::Error(_) => {}
+        }
+
+        None::<core::convert::Infallible>
+    });
+
+    let source = " <!-- a --> <h1>Hello</h1> world <a href=\"foo\" title=\"baz\">bar</a>";
+    Tokenizer::new_with_emitter(source, emitter).finish();
+    assert_eq!(source.as_bytes(), rt, "{} != {}", source, rt.escape_ascii());
+}

--- a/src/emitters/callback.rs
+++ b/src/emitters/callback.rs
@@ -276,7 +276,7 @@ where
     }
 
     fn flush_attribute_name(&mut self) {
-        self.flush_current_characters();
+        self.flush_open_start_tag();
 
         if !self.emitter_state.current_attribute_name.is_empty() {
             self.callback_state.emit_event(
@@ -310,6 +310,8 @@ where
     }
 
     fn flush_open_start_tag(&mut self) {
+        self.flush_current_characters();
+
         if matches!(self.emitter_state.current_tag_type, Some(CurrentTag::Start))
             && !self.emitter_state.current_tag_name.is_empty()
         {


### PR DESCRIPTION
`text <tag attr>` was improperly emitted as `<tagtext attr>`.

I wasn’t sure where to put a test since the only test for this code seems to be in an example, so I just added a test to the example that tries to exercise more of this code.