### PR TITLE
fix(ci): fix benchmark workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           crate: bencher_cli
           git: https://github.com/bencherdev/bencher
-          ref: f6832c1c
-      - run: sudo apt-get install -y valgrind
-      - run: bencher run --if-branch "$GITHUB_REF_NAME" --else-if-branch "$GITHUB_BASE_REF" --else-if-branch main --err --github-actions ${{ secrets.GITHUB_TOKEN }} --ci-only-thresholds --ci-only-on-alert "cargo bench"
+          rev: 4c83b25441d145ee273adaf74be30f2382e6ba85
+      - run: sudo apt-get update && sudo apt-get install -y valgrind
+      - run: bencher run --branch "${{ github.head_ref || github.ref_name }}" --start-point "${{ github.base_ref || 'main' }}" --start-point-clone-thresholds --err --github-actions ${{ secrets.GITHUB_TOKEN }} --ci-only-thresholds --ci-only-on-alert "cargo bench"


### PR DESCRIPTION
## Problems

1. **`apt-get install -y valgrind` fails with 404** — the runner image's apt package index is stale; `libc6-dbg_2.39-0ubuntu8.7_amd64.deb` no longer exists in the repos.

2. **bencher args are broken** — `baptiste0928/cargo-install` does not support the `ref` input (warns "Unexpected input(s) 'ref'"), so it silently installed the latest bencher_cli (v0.6.11) instead of the pinned `f6832c1c`. In v0.6.11, `--if-branch`/`--else-if-branch` are aliases for `--branch`/`--start-point`, and `--start-point` takes a single value — so the old command failed with `the argument '--start-point <START_POINT>' cannot be used multiple times`.

## Changes

- Add `sudo apt-get update` before `apt-get install`.
- Pin bencher_cli via the correct `rev` input (v0.6.11, `4c83b254`).
- Update `bencher run` args to v0.6.11 syntax: `--branch`/`--start-point` (with `--start-point-clone-thresholds` to preserve the old behavior of cloning thresholds when the PR branch is created).